### PR TITLE
Add spaces in logs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -104,7 +104,7 @@ const { GH_TOKEN, GIST_ID, USERNAME, DAYS } = process.env;
     console.log(`\n`);
     langs.forEach((l) =>
       console.log(
-        `${l.name}: ${l.count}files ${l.additions + l.deletions}changes`
+        `${l.name}: ${l.count} files, ${l.additions + l.deletions} changes`
       )
     );
 


### PR DESCRIPTION
These are the logs from my Github Action:

> ```
> TypeScript: 166files 3544changes
> Vue: 122files 3051changes
> SVG: 5files 105changes
> JavaScript: 10files 68changes
> YAML: 6files 16changes
> ```

As you can see, some spaces are missing. I've added some.