### PR TITLE
Run apt-get update before install

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -24,6 +24,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
+      - run: sudo apt-get update
       - run: sudo apt-get install cmake pkg-config libicu-dev zlib1g-dev libcurl4-openssl-dev libssl-dev ruby-dev
       - run: sudo gem install github-linguist
       - run: npm install


### PR DESCRIPTION
My workflows stopped working a few days ago with the following error message:

```log
Err:6 http://security.ubuntu.com/ubuntu bionic-updates/main amd64 libcurl4-openssl-dev amd64 7.58.0-2ubuntu3.12
  404  Not Found [IP: 52.252.75.106 80]
Get:7 http://ppa.launchpad.net/ondrej/php/ubuntu bionic/main amd64 icu-devtools amd64 65.1-1+ubuntu18.04.1+deb.sury.org+1 [198 kB]
Fetched 14.2 MB in 1s (9897 kB/s)
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/c/curl/libcurl4-openssl-dev_7.58.0-2ubuntu3.12_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```

And it's true that you should always run `apt-get update` before `apt-get install`.

I've added it to my workflow and it's fixed now, so I wanted to share the fix :wrench: 

![image](https://user-images.githubusercontent.com/17952318/113501709-8dc9ae00-9527-11eb-8bb5-b33d2a6df14d.png)
