### PR TITLE
Fix linguist 7.16 parsing

### DIFF
--- a/src/linguist.js
+++ b/src/linguist.js
@@ -19,7 +19,7 @@ const parseOutput = (text) => {
   const map = {};
   let parsingLang = "";
   text.split("\n").forEach((line) => {
-    const mv = line.match(/^(?<percent>[\d.]+)%\s+(?<language>\w+)/)?.groups;
+    const mv = line.match(/^(?<percent>[\d.]+)%\s+[\d.]+\s(?<language>\w+)/)?.groups;
     if (mv) {
       map[mv.language] = { percent: mv.percent, paths: [] };
       return;


### PR DESCRIPTION
With [linguist 7.16](https://github.com/github/linguist/releases/tag/v7.16.0), and especially [this PR](https://github.com/github/linguist/pull/5464), the output is a little bit different, which breaks the GitHub Action:

```diff
- 21.81%  JavaScript
+ 21.81%  12975      JavaScript
```

This PR fixes the problem, but #7 is a better alternative IMO.