### PR TITLE
🩹 Issue 18: fix deprecation warning

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   run:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
   The ubuntu-18.04 environment is deprecated,
   consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead.
   For more details see https://github.com/actions/virtual-environments/issues/6002

This PR fixes issue #18 👍🏼 