### PR TITLE
🩹 Issue 17: fix deprecation warning

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -9,15 +9,15 @@ jobs:
   run:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@master
+        uses: actions/setup-node@v3
         with:
           node-version: "16.x"
 
       - name: Cache dependencies
-        uses: actions/cache@master
+        uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -9,15 +9,15 @@ jobs:
   run:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@master
         with:
           node-version: "16.x"
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@master
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
   Node.js 12 actions are deprecated.
   For more information see:
   https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

   Please update the following actions to use Node.js 16: actions/checkout@v2
   Using version v3, latest or master: actions/checkout#689

   Please update the following actions to use Node.js 16: actions/setup-node@v2, actions/cache@v2
   Using version v2.285.0, latest or master: actions/setup-node/pull/414 and actions/cache/pull/729

This PR fixes issue #17 👍🏼 